### PR TITLE
QA1: Document build fix (Fixes #1)

### DIFF
--- a/docs/qa_fixes.md
+++ b/docs/qa_fixes.md
@@ -1,0 +1,6 @@
+Problem: Docker image failed to build due to outdated base image and missing dependencies. 
+Fix applied: Updated Dockerfile to a compatible base image, added required system dependencies, and upgraded outdated package versions. This build now succeeds when running 'docker -t myapp .'.
+Reproduction steps (original): 
+1. Run 'docker build -t myapp .'
+2. Build failed with missing/incompatible dependencies. 
+Status: Verified locally after chnages.


### PR DESCRIPTION
This PR documents the resolution for QA 1.

Problem
- Docker image failed to build due to outdated base image and missing system deps.

Fix
- Updated Dockerfile to use a compatible base image.
- Added required system dependencies.
- Verified local build with: `docker build -t myapp .`

Links
- Fixes #1 
